### PR TITLE
Jobs get killed on SIGTERM

### DIFF
--- a/vmck/__init__.py
+++ b/vmck/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'vmck.apps.VmckConfig'

--- a/vmck/apps.py
+++ b/vmck/apps.py
@@ -1,5 +1,18 @@
 from django.apps import AppConfig
 
+import signal
+
 
 class VmckConfig(AppConfig):
     name = 'vmck'
+
+    @staticmethod
+    def signalHandler(signalNumber, frame):
+        from .models import Job
+        from .jobs import kill
+
+        for job in Job.objects.all():
+            kill(job)
+
+    def ready(self):
+        signal.signal(signal.SIGTERM, VmckConfig.signalHandler)


### PR DESCRIPTION
Issue #51. I do not know if it's better to kill the jobs by making `DELETE` requests to the api or as it is now by calling `jobs.kill(JobObject)`. What would be the best choice? @mgax @gabriel-v 