### PR TITLE
Dirty interface

### DIFF
--- a/vagrant-files/Vagrantfile
+++ b/vagrant-files/Vagrantfile
@@ -1,0 +1,21 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "base"
+
+  if Vagrant.has_plugin?('vagrant-env')
+    config.env.enable
+  end
+
+  config.nfs.functional = false
+
+  config.vm.provision 'shell', inline: "cd /vagrant; ls -al"
+
+  config.vm.provider :vmck do |vmck|
+    vmck.image_path = 'cluster-master.qcow2.tar.gz'
+    vmck.vmck_url = ENV['VMCK_URL']
+    vmck.memory = 1024 * 2
+    vmck.cpus = 1
+  end
+end

--- a/vmck/base_settings.py
+++ b/vmck/base_settings.py
@@ -24,6 +24,10 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'vmck.urls'
 
+MEDIA_ROOT = base_dir / 'data' / 'uploads'
+FILE_UPLOAD_DIRECTORY_PERMISSIONS = 0o731
+FILE_UPLOAD_PERMISSIONS = 0o666
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/vmck/forms.py
+++ b/vmck/forms.py
@@ -1,0 +1,6 @@
+from django import forms
+
+
+class UploadFileForm(forms.Form):
+    file = forms.FileField(label='Select archive',
+                           widget=forms.FileInput(attrs={'accept': 'application/zip'}))  # noqa: E501

--- a/vmck/settings.py
+++ b/vmck/settings.py
@@ -10,6 +10,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 DEBUG = is_true(os.environ.get('DEBUG'))
 
 _hostname = os.environ.get('HOSTNAME')
+
 if _hostname:
     ALLOWED_HOSTS = [_hostname]
 

--- a/vmck/templates/vmck/homepage.html
+++ b/vmck/templates/vmck/homepage.html
@@ -1,1 +1,9 @@
-hi!
+<body>
+    <p>Welcome to VMChecker</p>
+
+    <form enctype="multipart/form-data" method="post">
+        {% csrf_token %}
+        {{ form }}
+        <input type="submit" value="Submit">
+    </form>
+</body>

--- a/vmck/views.py
+++ b/vmck/views.py
@@ -1,5 +1,28 @@
 from django.shortcuts import render
+from django.core.files.storage import FileSystemStorage
+from .forms import UploadFileForm
+from zipfile import ZipFile
+from tempfile import TemporaryDirectory
+from shutil import copy
+from .base_settings import base_dir
+import subprocess
 
 
 def homepage(request):
-    return render(request, 'vmck/homepage.html')
+    if request.method == 'POST'and request.FILES:
+        form = UploadFileForm(request.POST, request.FILES)
+        if form.is_valid():
+            fs = FileSystemStorage()
+            fs.save(request.FILES['file'].name, request.FILES['file'])
+            zp = ZipFile(fs.path(request.FILES['file'].name))
+            with TemporaryDirectory() as tmp_dir:
+                print(tmp_dir)
+                zp.extractall(tmp_dir)
+                copy(base_dir / 'vagrant-files' / 'Vagrantfile', tmp_dir)
+                proc = subprocess.Popen('docker run --env VMCK_URL=http://127.0.0.1:8000 --network="host" -it --rm --volume $(pwd):/homework  vmck/vagrant-vmck:latest /bin/bash -c "cd /homework; vagrant up; vagrant destroy -f"', stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, cwd=tmp_dir)  # noqa: E501
+                while proc.poll() is None:
+                    print(''.join(proc.stdout.readline().decode('utf-8').strip()))  # noqa: E501
+    else:
+        form = UploadFileForm()
+
+    return render(request, 'vmck/homepage.html', {'form': form})


### PR DESCRIPTION
I would like to know if my thought process is lining up with what we discussed. Let me get you through the clutter down there. 
What happens is that first the user sends a `zip` archive with his homework. Now we use django's `FileSystemStorage` to save the archive (it has some nice features - e.g: if a file exists, when was it created - that we can use to reduce multiple submissions of a user to only the most recent one, if he has 10 submissions we only want to check the most recent one). 
Next I thought that we should unzip the archive in a temporary directory. Then we just copy the corresponding `Vagrantfile` in that same directory ( if we have a `SO` submission we copy the `SO` Vagrantfile and so on - maybe we could have a single Vagrantfile and we render it with jinja?- ). 
Next up I kind of feel I have too much complexity. The basic idea is to let `vagrant` sync the current folder on the job VM and then check the homework through `vagrant ssh`. As vmck has no access to vagrant I used the docker image for vagrant-vmck (this won't work in nomad as we would have a `docker in docker` bit of problem) and gave it access to the current temp directory. And that docker container does the `vagrant up`, syncing and checking.
In the end after the submission is done we could have a trigger that gets the result and gives it back to the user.
This is what I came up with until now. What do you think?
**THIS IS A DRAFT! PLEASE DON'T JUDGE THE CODING STYLE!**
