### PR TITLE
Fix better check

### DIFF
--- a/vmck/backends/check-ssh.sh
+++ b/vmck/backends/check-ssh.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo 'a' | telnet -e a $1 $2

--- a/vmck/backends/qemu.py
+++ b/vmck/backends/qemu.py
@@ -33,9 +33,9 @@ def services(job):
             'PortLabel': 'ssh',
             'Checks': [
                 {
-                    'Name': f'{name} tcp',
+                    'Name': f'{name} ssh check',
                     'InitialStatus': 'critical',
-                    'Type': 'tcp',
+                    'Type': 'script',
                     'Command': '/opt/vmck/vmck/backends/check-ssh.sh',
                     'Args': [
                         '${NOMAD_IP_ssh}', "${NOMAD_PORT_ssh}"

--- a/vmck/backends/qemu.py
+++ b/vmck/backends/qemu.py
@@ -33,13 +33,10 @@ def services(job):
             'PortLabel': 'ssh',
             'Checks': [
                 {
-                    'Name': f'{name} ssh check',
+                    'Name': f'{name} tcp',
                     'InitialStatus': 'critical',
-                    'Type': 'script',
-                    'Command': '/opt/vmck/vmck/backends/check-ssh.sh',
-                    'Args': [
-                        '${NOMAD_IP_ssh}', "${NOMAD_PORT_ssh}"
-                    ],
+                    'Type': 'tcp',
+                    'Port': '${NOMAD_PORT_ssh}',
                     'Interval': 1 * second,
                     'Timeout':  1 * second,
                 },


### PR DESCRIPTION
The `script` check doens't work on the qemu driver as nomad can't access the file system, and I was lucky during testing, because the old check didn't work the way it was supposed to. It still did a tcp check. 