### PR TITLE
fix vmck failure if given non existent ENV as name

### DIFF
--- a/vmck/api.py
+++ b/vmck/api.py
@@ -29,7 +29,7 @@ def create_job(request):
     options.setdefault('cpus', 1)
     options.setdefault('memory', 512)
     options.setdefault('image_path', 'imgbuild-master.qcow2.tar.gz')
-    options.setdefault('name', 'default')
+    options['name'] = options.get('name') or 'default'
     options['cpu_mhz'] = options['cpus'] * settings.QEMU_CPU_MHZ
 
     job = jobs.create(get_backend(), options)


### PR DESCRIPTION
Fix #93 