### PR TITLE
Connect to ssh and check for server signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.env
 /*.egg-info
 /data
-/ci/.vagrant
+/.vagrant
 /.pytest_cache


### PR DESCRIPTION
SSH connections to guest VMs go through QEMU user networking's `hostfwd` mechanism of tcp proxying. For some reason, it starts accepting connections when `qemu` itself starts, way before the VM is finised booting and its ssh can answer. The connection hangs until sshd is ready and accepts connections. If the VM takes a long time to boot, this causes Vagrant's ssh to time out.

This fix ~changes the healthcheck~ accepts the fact that qemu jobs can't be checked with scripts, so vmck does its own healthcheck, to wait for the SSH header, e.g. `SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3`, before it's happy.
