### PR TITLE
Add setting for vm port range

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+[![Build Status](https://frisbee.vmchecker.cs.pub.ro/api/badges/vmck/vmck/status.svg)](https://frisbee.vmchecker.cs.pub.ro/vmck/vmck)
+
 # Vmck
 Vmck is a virtual machine service that runs QEMU and Docker images in a Nomad
 cluster.

--- a/examples/vmck.nomad
+++ b/examples/vmck.nomad
@@ -109,6 +109,8 @@ job "vmck" {
           VMCK_URL = 'http://{{ env "NOMAD_ADDR_http" }}'
           BACKEND = "docker"
           QEMU_CPU_MHZ = 300
+          VM_PORT_RANGE_START = 10000
+          VM_PORT_RANGE_STOP = 20000
           EOF
         destination = "local/vmck.env"
         env = true

--- a/vmck/backends/qemu.py
+++ b/vmck/backends/qemu.py
@@ -40,8 +40,9 @@ def resources(vm_port, options):
 
 def task_group(job, options):
     tasks = []
-    vm_port = random_port(settings.VM_PORT_RANGE_START,
-                          settings.VM_PORT_RANGE_STOP,
+    vm_port = random_port(
+        settings.VM_PORT_RANGE_START,
+        settings.VM_PORT_RANGE_STOP,
     )
 
     prefix = settings.QEMU_IMAGE_PATH_PREFIX.rstrip('/') + '/'

--- a/vmck/backends/qemu.py
+++ b/vmck/backends/qemu.py
@@ -40,7 +40,9 @@ def resources(vm_port, options):
 
 def task_group(job, options):
     tasks = []
-    vm_port = random_port()
+    vm_port = random_port(settings.VM_PORT_RANGE_START,
+                          settings.VM_PORT_RANGE_STOP,
+    )
 
     prefix = settings.QEMU_IMAGE_PATH_PREFIX.rstrip('/') + '/'
     image = urljoin(prefix, options['image_path'])

--- a/vmck/settings.py
+++ b/vmck/settings.py
@@ -40,6 +40,13 @@ VMCK_BACKEND = os.environ.get('BACKEND', 'docker')
 QEMU_IMAGE_PATH_PREFIX = os.environ.get('QEMU_IMAGE_PATH_PREFIX')
 QEMU_CPU_MHZ = int(os.environ.get('QEMU_CPU_MHZ', QEMU_CPU_MHZ))
 
+VM_PORT_RANGE_START = int(os.environ.get('VM_PORT_RANGE_START',
+                                         10000,
+))
+VM_PORT_RANGE_STOP = int(os.environ.get('VM_PORT_RANGE_STOP',
+                                         20000,
+))
+
 _ssh_username = SSH_USERNAME
 SSH_USERNAME = os.environ.get('SSH_USERNAME', _ssh_username)
 

--- a/vmck/settings.py
+++ b/vmck/settings.py
@@ -40,11 +40,13 @@ VMCK_BACKEND = os.environ.get('BACKEND', 'docker')
 QEMU_IMAGE_PATH_PREFIX = os.environ.get('QEMU_IMAGE_PATH_PREFIX')
 QEMU_CPU_MHZ = int(os.environ.get('QEMU_CPU_MHZ', QEMU_CPU_MHZ))
 
-VM_PORT_RANGE_START = int(os.environ.get('VM_PORT_RANGE_START',
-                                         10000,
+VM_PORT_RANGE_START = int(os.environ.get(
+    'VM_PORT_RANGE_START',
+    10000,
 ))
-VM_PORT_RANGE_STOP = int(os.environ.get('VM_PORT_RANGE_STOP',
-                                         20000,
+VM_PORT_RANGE_STOP = int(os.environ.get(
+    'VM_PORT_RANGE_STOP',
+    20000,
 ))
 
 _ssh_username = SSH_USERNAME


### PR DESCRIPTION
On the production sever the ports `10000` and `10001` are already reserved and there were some collisions with newly created VMs.